### PR TITLE
Update Callable method to be ruby 3 compatible

### DIFF
--- a/lib/spree_extension/service_module.rb
+++ b/lib/spree_extension/service_module.rb
@@ -5,8 +5,8 @@ unless defined?(Spree::ServiceModule)
   module Spree
     module ServiceModule
       module Callable
-        def call(*args)
-          new.call(*args).tap do |result|
+        def call(*args, **kwargs)
+          new.call(*args, **kwargs).tap do |result|
             return yield(result) if block_given?
           end
         end


### PR DESCRIPTION
This updates the Callable method to be Ruby3 compatible.

The issue is how Ruby3 separated positional from keyword arguments. See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This fixes the issue for this gem, making it possible to upgrade other gems that depend on it (spree_avatax_official for example) to Ruby 3+.

Thank you for looking!